### PR TITLE
minor typo in readme and link rt library

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ http://www.gnu.org/copyleft/gpl.html
 On Debian-based systems (like Ubuntu), this will install the required
 components:
 
-    $ sudo apt-get install cmake libboost-dev libboost-program-option-dev libboost-system-dev libboost-thread-dev
+    $ sudo apt-get install cmake libboost-dev libboost-program-options-dev libboost-system-dev libboost-thread-dev
 
 ### Optional
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,3 @@
 
 ADD_EXECUTABLE( simple-example "SimpleExample.cpp" )
-TARGET_LINK_LIBRARIES( simple-example ${Boost_LIBRARIES} )
+TARGET_LINK_LIBRARIES( simple-example ${Boost_LIBRARIES} rt )


### PR DESCRIPTION
there are 2 minor modifications in the pull request.  i fixed a minor typo in the readme, and it now links with the rt library which is needed by clock_gettime.

i verified these on Linux Ubuntu 12.04.
